### PR TITLE
Add a task to set the permissions for the user's home directory

### DIFF
--- a/create/playbook.yml
+++ b/create/playbook.yml
@@ -12,6 +12,11 @@
         name: "{{ username }}"
         shell: /bin/bash
 
+    - name: Set home directory permissions
+      file:
+        mode: 0750
+        path: /home/{{ username }}
+
     - name: Add ssh public key as authorized key for user
       authorized_key:
         user: "{{ username }}"


### PR DESCRIPTION
## 🗣 Description

This pull request adds a task that sets the permissions of the user's home directory to `0750`.

## 💭 Motivation and Context

Hardened systems will require permissions of `0750` to pass the Nessus compliance scan, so we may as well use that everywhere since it won't interfere with anything else the credentialed user is doing.

## 🧪 Testing

@dav3r ran this code against an AMI we were testing and it worked as expected.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
